### PR TITLE
Load classpath in windows

### DIFF
--- a/jnotebook-core/src/main/java/tech/catheu/jnotebook/jshell/ShellProvider.java
+++ b/jnotebook-core/src/main/java/tech/catheu/jnotebook/jshell/ShellProvider.java
@@ -115,22 +115,22 @@ public class ShellProvider {
     final BufferedReader reader =
             new BufferedReader(new InputStreamReader(pr.getInputStream()));
     final List<String> classpaths = reader.lines().toList();
-    // mvn (-q) does not suppress errors, but all error line start with "[ERROR]
+    // mvn (-q) does not suppress errors, but all error line start with "[ERROR]"
     // there's cases where we get some classpaths, but some module fails, we can load the successful ones.
     final List<String> errors = classpaths.stream().filter(s -> s.startsWith("[ERROR]")).toList();
-    final List<String> filteredClasspaths = classpaths.stream().filter(s -> !s.startsWith("[ERROR]")).toList();
     if (!errors.isEmpty()) {
-      LOG.warn("Maven dependencies command ran with some errors: %s".formatted(errors.get(0)));// only thr first line has the relevant error (not sure though)
+      // only the first line has the relevant error (not sure though)
+      throw new RuntimeException("Maven dependencies command exited with errors: %s".formatted(errors.get(0)));
     }
-    if (filteredClasspaths.isEmpty()) {
+    if (classpaths.isEmpty()) {
       LOG.warn("Maven dependencies command ran successfully, but classpath is empty");
       return "";
-    } else if (filteredClasspaths.size() == 1) {
-      return filteredClasspaths.get(0);
+    } else if (classpaths.size() == 1) {
+      return classpaths.get(0);
     } else {
       LOG.warn(
               "Maven dependencies command ran successfully, but multiple classpath were returned. This can happen with multi-modules projects. Combining all classpath.");
-      return String.join(":", filteredClasspaths);
+      return String.join(":", classpaths);
     }
   }
 

--- a/jnotebook-core/src/main/java/tech/catheu/jnotebook/jshell/ShellProvider.java
+++ b/jnotebook-core/src/main/java/tech/catheu/jnotebook/jshell/ShellProvider.java
@@ -26,17 +26,18 @@ import static tech.catheu.jnotebook.utils.JavaUtils.optional;
 
 public class ShellProvider {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ShellProvider.class);
-    private static final String MAVEN_PROJECT_FILE = "pom.xml";
-    private static final String MAVEN_WRAPPER_FILE =
-            IS_OS_WINDOWS ? "mvnw.cmd" : "mvnw";
-    private static final String GRADLE_PROJECT_FILE = "build.gradle";
-    public static final String MAVEN_DEPENDENCY_COMMAND =
-            " -q exec:exec -Dexec.executable=echo -Dexec.args=\"%classpath\"";
-    // We need to escape the '.' in the command otherwise it fails
-    public static final String MAVEN_DEPENDENCY_COMMAND_WINDOWS = " -q exec:exec -Dexec^.executable=cmd -Dexec^.args=\"/c echo %classpath\"";
-    private final Deque<PowerJShell> preparedShells;
-    private final Main.SharedConfiguration configuration;
+  private static final Logger LOG = LoggerFactory.getLogger(ShellProvider.class);
+  private static final String MAVEN_PROJECT_FILE = "pom.xml";
+  private static final String MAVEN_WRAPPER_FILE =
+          IS_OS_WINDOWS ? "mvnw.cmd" : "mvnw";
+  private static final String GRADLE_PROJECT_FILE = "build.gradle";
+  public static final String MAVEN_DEPENDENCY_COMMAND =
+          " -q exec:exec -Dexec.executable=echo -Dexec.args=\"%classpath\"";
+  // We need to escape the '.' in the command otherwise it fails
+  public static final String MAVEN_DEPENDENCY_COMMAND_WINDOWS =
+          " -q exec:exec -Dexec^.executable=cmd -Dexec^.args=\"/c echo %classpath\"";
+  private final Deque<PowerJShell> preparedShells;
+  private final Main.SharedConfiguration configuration;
 
   private String resolvedClasspath = null;
   private final LocalStorage localStorage;


### PR DESCRIPTION
Implemented loading the maven classpath for windows: 

- added the necessary windows command 
- added some handling for the partial error case : when we run the mvn command to get the classpaths, there's a case when some dependency fails to download, or some module fails to build, however, we get some of the classpath, I just assumed that we can load the succeful part, and log a wrning with the error, if you want this to behave differently feel free to let me know and I'll change it. here's a screenshot for this case : 

![image](https://github.com/cyrilou242/jnotebook/assets/5917134/fe0417b1-91aa-4ac9-bc42-f67682c32189)


